### PR TITLE
Fix cmake warning

### DIFF
--- a/ClusterExporterBin/CMakeLists.txt
+++ b/ClusterExporterBin/CMakeLists.txt
@@ -78,7 +78,6 @@ install(TARGETS ${CLUSTER_EXPORTER_BIN}
 )
 
 add_custom_command(TARGET ${CLUSTER_EXPORTER_BIN} POST_BUILD
-    DEPENDS ClusterExporterBin
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>

--- a/ClusterExporterJson/CMakeLists.txt
+++ b/ClusterExporterJson/CMakeLists.txt
@@ -72,7 +72,6 @@ install(TARGETS ${CLUSTER_EXPORTER_JSON}
 )
 
 add_custom_command(TARGET ${CLUSTER_EXPORTER_JSON} POST_BUILD
-    DEPENDS ClusterExporterJson
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>

--- a/ClusterLoaderBin/CMakeLists.txt
+++ b/ClusterLoaderBin/CMakeLists.txt
@@ -80,7 +80,6 @@ install(TARGETS ${CLUSTER_LOADER_BIN}
 )
 
 add_custom_command(TARGET ${CLUSTER_LOADER_BIN} POST_BUILD
-    DEPENDS ClusterLoaderBin
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>

--- a/ClusterLoaderJson/CMakeLists.txt
+++ b/ClusterLoaderJson/CMakeLists.txt
@@ -80,7 +80,6 @@ install(TARGETS ${CLUSTER_LOADER_JSON}
 )
 
 add_custom_command(TARGET ${CLUSTER_LOADER_JSON} POST_BUILD
-    DEPENDS ClusterLoaderJson
     COMMAND "${CMAKE_COMMAND}"
         --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>


### PR DESCRIPTION
Same warning for all four targets:
```cmake
CMake Warning (dev) at ClusterIO/ClusterLoaderBin/CMakeLists.txt:82 (add_custom_command):
  The following keywords are not supported when using
  add_custom_command(TARGET): DEPENDS.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.
```